### PR TITLE
Fix issue with 2 string (Piko 7.0), closes gieljnssns/KostalPyko#2

### DIFF
--- a/kostalpyko/kostalpyko.py
+++ b/kostalpyko/kostalpyko.py
@@ -147,11 +147,23 @@ class Piko:
 
     def get_l3_voltage(self):
         """returns the voltage from line 3 in V"""
-        return int(self._get_raw_content()[12])
+        raw_content = self._get_raw_content()
+        if len(raw_content) < 14:
+            # 2 Strings
+            return int(raw_content[11])
+        else:
+            # 3 Strings
+            return int(raw_content[12])
 
     def get_l3_power(self):
         """returns the power from line 3 in W"""
-        return int(self._get_raw_content()[14])
+        raw_content = self._get_raw_content()
+        if len(raw_content) < 14:
+            # 2 Strings
+            return int(raw_content[12])
+        else:
+            # 3 Strings
+            return int(raw_content[14])
 
     def _get_raw_content(self):
         """returns all values as a list"""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='kostalpyko',
-    version='v0.2',
+    version='v0.3',
     packages=['tests', 'kostalpyko'],
     install_requires=[
           'lxml',


### PR DESCRIPTION
While upgrade the python version and renamed it, you've missed 2 of my last fixes for piko 7.0 which only have 2 strings.

So I fixed the functions again:
 - get_l3_voltage
 - get_l3_power
to avoid the `IndexError: list index out of range` 